### PR TITLE
Updates for search

### DIFF
--- a/assets/javascripts/controllers/search_controller.js
+++ b/assets/javascripts/controllers/search_controller.js
@@ -3,8 +3,14 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [ "query", "results", "resultsList" ]
 
+  connect() {
+    this.hideResultsListener = event => this.hideResults(event)
+    document.addEventListener('click', this.hideResultsListener)
+  }
+
   disconnect() {
     this.reset()
+    document.removeEventListener('click', this.hideResultsListener)
   }
 
   fetchResults() {
@@ -22,8 +28,10 @@ export default class extends Controller {
     this.queryTarget.value = ""
   }
 
-  hideResults() {
-    this.resultsListTarget.classList.add('hide-search-results')
+  hideResults(event) {
+    if (event && event.target != this.queryTarget) {
+      this.resultsListTarget.classList.add('hide-search-results')
+    }
   }
 
   navigateResults(event) {

--- a/assets/javascripts/controllers/search_results_controller.js
+++ b/assets/javascripts/controllers/search_results_controller.js
@@ -22,18 +22,24 @@ export default class extends Controller {
 
     switch(event.keyCode) {
       case downKey:
-        console.log("down arrow")
         this.selectNextResult()
         break;
       case upKey:
-        console.log("up arrow")
         this.selectPreviousResult()
         break;
       case enterKey:
-        console.log("enter key")
         this.goToSelectedResult()
         break;
     }
+  }
+
+  setFocus(event) {
+    this.resultTargets.forEach((element, index) => {
+      element.classList.toggle("search-result--current", element.firstElementChild == event.target)
+      if (element.firstElementChild == event.target) {
+        this.currentResultIndex = index
+      }
+    })
   }
 
   // private

--- a/assets/stylesheets/search.scss
+++ b/assets/stylesheets/search.scss
@@ -50,10 +50,6 @@
     color: black;
     padding: .5rem .75rem;
     display: block;
-    &:hover {
-      background: #ff161f;
-      color: #fff;
-    }
   }
   &:first-of-type {
     margin-top: .25rem;
@@ -62,7 +58,6 @@
     margin-bottom: .25rem;
   }
 }
-
 
 .search-result--current a {
   background-color: #ff161f;

--- a/source/partials/_navigation.html.erb
+++ b/source/partials/_navigation.html.erb
@@ -11,7 +11,7 @@
   <div class="collapse navbar-collapse align-center" id="nav-search">
     <div class="search w-100">
       <div class="input-group search" data-controller="search">
-        <%= text_field_tag :query, value: "", class: "form-control", placeholder: "Search artists and bands...", "aria-label" => "Search", autocomplete: "off", data: { action: "keyup->search#fetchResults keydown->search#navigateResults blur->search#hideResults focus->search#fetchResults", target: "search.query" } %>
+        <%= text_field_tag :query, value: "", class: "form-control", placeholder: "Search artists and bands...", "aria-label" => "Search", autocomplete: "off", data: { action: "keyup->search#fetchResults keydown->search#navigateResults focus->search#fetchResults", target: "search.query" } %>
         <div class="input-group-append">
           <button class="" type="button" data-action="click->search#fetchResults">
             <span class="oi oi-magnifying-glass text-primary"></span>
@@ -19,16 +19,36 @@
         </div>
         <div data-target="search.results">
           <ul class="search-results hide-search-results" data-controller="search-results" data-target="search.resultsList">
-            <li class="search-result" data-target="search-results.result"><a href="#">Steve Perry</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Tom Petty</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Tom Petty and the Heartbreakers</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Liz Phair</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Phantogram</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="/artist-details/index.html">Phish</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Phonte</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Édith Piaf</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Pia Mia</a></li>
-            <li class="search-result" data-target="search-results.result"><a href="#">Pierce the Veil</a></li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Steve Perry</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Tom Petty</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Tom Petty and the Heartbreakers</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Liz Phair</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Phantogram</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="/artist-details/index.html">Phish</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Phonte</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Édith Piaf</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Pia Mia</a>
+            </li>
+            <li class="search-result" data-target="search-results.result" data-action="mouseover->search-results#setFocus">
+              <a href="#">Pierce the Veil</a>
+            </li>
           </ul>
           <!-- // end search-results -->
         </div>


### PR DESCRIPTION
Updating search so that you can select results with either a mouse or the keyboard.

To get search so it works with both the keyboard AND the mouse I had to make some changes. First, I got rid of the `blur` handler on the search query text field. The `search_controller.js` now installs an event listener on the `document` that listens for clicks. If the click is outside the search query field, it hides the search results.

Next, I got rid of the hover style on the `search-result` elements because it was causing both the element being hovered over as well as the one currently selected by the keyboard to "active". There is now a `mouseover` event handler on each `search-result` element that will set that element to the current search result and apply the `search-result--current` style (which was the same as the hover style).
