### PR TITLE
Add jquery-ui and jquery-tageditor

### DIFF
--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -1,6 +1,8 @@
 import { Application } from "stimulus"
 import { definitionsFromContext } from "stimulus/webpack-helpers"
-import $ from 'jquery';
+
+import 'jquery-ui'
+import 'jquery-tageditor'
 import 'popper.js'
 import 'bootstrap'
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "d3": "^5.7.0",
     "d3-scale-cluster": "^1.3.1",
     "jquery": "^3.3.1",
+    "jquery-tageditor": "^1.0.1",
+    "jquery-ui-dist": "^1.12.1",
     "popper.js": "^1.14.6",
     "stimulus": "^1.1.0",
     "topojson": "^3.0.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,12 @@ module.exports = {
     filename: 'assets/javascripts/[name].js',
     path: path.resolve(__dirname, '.tmp/dist')
   },
-
+  resolve: {
+    alias: {
+      'jquery-ui': 'jquery-ui-dist/jquery-ui.js',
+      'jquery-tageditor': 'jquery-tageditor/jquery.tag-editor.js',
+    },
+  },
   module: {
     rules: [
       {
@@ -61,7 +66,11 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'assets/stylesheets/[name].css'
-    })
-  ]
+      filename: 'assets/stylesheets/[name].css',
+    }),
+    new webpack.ProvidePlugin({
+      $: 'jquery',
+      jQuery: 'jquery',
+    }),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,6 +2945,16 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jquery-tageditor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jquery-tageditor/-/jquery-tageditor-1.0.1.tgz#35750462c4342d71809046702279b3acfcfb2791"
+  integrity sha512-PrTZ8PlHQvn5s4xRuUrEDMV5Z2whwXcsknNTdc9sNC3UEtqkJt+s1p4/xsu67iZwHwcS7pwDyY0RAlzBzPv6oA==
+
+jquery-ui-dist@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz#5c0815d3cc6f90ff5faaf5b268a6e23b4ca904fa"
+  integrity sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo=
+
 jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"


### PR DESCRIPTION
Adding `jquery-ui` and `jquery-tageditor` and switching to using the `webpack.ProvidePlugin` to make `jQuery` and `$` available without importing anything. This ensures that both the `jQuery` and `$` variables exist for other imported javascript.

I also added aliases to the Webpack config for `jquery-ui` and `jquery-tageditor` so that importing those will import the correct files.